### PR TITLE
fix: [CHK-2323] use same decoder search param to enable pdv cache

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/helpdesk/services/HelpdeskService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/helpdesk/services/HelpdeskService.kt
@@ -30,12 +30,13 @@ class HelpdeskService(
         pageSize: Int,
         searchTransactionRequestDto: HelpDeskSearchTransactionRequestDto
     ): Mono<SearchTransactionResponseDto> {
+        val confidentialMailUtils = ConfidentialMailUtils(confidentialDataManager)
         val totalEcommerceCount =
             ecommerceTransactionDataProvider
                 .totalRecordCount(
                     SearchParamDecoder(
                         searchParameter = searchTransactionRequestDto,
-                        confidentialMailUtils = ConfidentialMailUtils(confidentialDataManager)
+                        confidentialMailUtils = confidentialMailUtils
                     )
                 )
                 .onErrorResume(InvalidSearchCriteriaException::class.java) { Mono.just(0) }
@@ -72,8 +73,7 @@ class HelpdeskService(
                             searchParams =
                                 SearchParamDecoder(
                                     searchParameter = searchTransactionRequestDto,
-                                    confidentialMailUtils =
-                                        ConfidentialMailUtils(confidentialDataManager)
+                                    confidentialMailUtils = confidentialMailUtils
                                 ),
                             skip = skip,
                             limit = pageSize
@@ -92,8 +92,7 @@ class HelpdeskService(
                                 searchParams =
                                     SearchParamDecoder(
                                         searchParameter = searchTransactionRequestDto,
-                                        confidentialMailUtils =
-                                            ConfidentialMailUtils(confidentialDataManager)
+                                        confidentialMailUtils = confidentialMailUtils
                                     ),
                                 skip = skip,
                                 limit = pageSize
@@ -112,8 +111,7 @@ class HelpdeskService(
                                 searchParams =
                                     SearchParamDecoder(
                                         searchParameter = searchTransactionRequestDto,
-                                        confidentialMailUtils =
-                                            ConfidentialMailUtils(confidentialDataManager)
+                                        confidentialMailUtils = confidentialMailUtils
                                     ),
                                 skip = skip,
                                 limit = ecommerceRemainder


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Use same decoder parameter instance for all data provider call in order to use PDV cache and avoid multiple mail encrypt call
<!--- Describe your changes in detail -->

#### Motivation and Context
Search parameter decoder where instantiating creating a new confidential mail utils each time.
This way PDV encrypted mail were not cached and called both for count and find result query.
This modification is needed in order to avoid calling PDV multiple times while searching transaction by email for eCommerce DB, calling it only once
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
junit tests + Local tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.