### PR TITLE
fix: remove optional max staleness parameter

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,7 @@ pm.oracle.databaseName=\${PM_ORACLE_DATABASE_NAME}
 pm.oracle.userName=\${PM_ORACLE_USERNAME}
 pm.oracle.password=\${PM_ORACLE_PASSWORD}
 #Ecommerce mongo database configuration
-spring.data.mongodb.uri=mongodb://\${MONGO_USERNAME}:\${MONGO_PASSWORD}@\${MONGO_HOST}:\${MONGO_PORT}/?ssl=\${MONGO_SSL_ENABLED}&readPreference=secondary&maxStalenessSeconds=3600&minPoolSize=\${MONGO_MIN_POOL_SIZE}&maxPoolSize=\${MONGO_MAX_POOL_SIZE}&maxIdleTimeMS=\${MONGO_MAX_IDLE_TIMEOUT_MS}&connectTimeoutMS=\${MONGO_CONNECTION_TIMEOUT_MS}&socketTimeoutMS=\${MONGO_SOCKET_TIMEOUT_MS}&serverSelectionTimeoutMS=\${MONGO_SERVER_SELECTION_TIMEOUT_MS}&waitQueueTimeoutMS=\${MONGO_WAITING_QUEUE_MS}&heartbeatFrequencyMS=\${MONGO_HEARTBEAT_FREQUENCY_MS}
+spring.data.mongodb.uri=mongodb://\${MONGO_USERNAME}:\${MONGO_PASSWORD}@\${MONGO_HOST}:\${MONGO_PORT}/?ssl=\${MONGO_SSL_ENABLED}&readPreference=secondary&minPoolSize=\${MONGO_MIN_POOL_SIZE}&maxPoolSize=\${MONGO_MAX_POOL_SIZE}&maxIdleTimeMS=\${MONGO_MAX_IDLE_TIMEOUT_MS}&connectTimeoutMS=\${MONGO_CONNECTION_TIMEOUT_MS}&socketTimeoutMS=\${MONGO_SOCKET_TIMEOUT_MS}&serverSelectionTimeoutMS=\${MONGO_SERVER_SELECTION_TIMEOUT_MS}&waitQueueTimeoutMS=\${MONGO_WAITING_QUEUE_MS}&heartbeatFrequencyMS=\${MONGO_HEARTBEAT_FREQUENCY_MS}
 spring.data.mongodb.database=ecommerce
 deadLetter.queueMapping=\${SEARCH_DEAD_LETTER_QUEUE_MAPPING}
 #PDV configuration


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Remove `maxStalenessSeconds` parameter from connection string in order to make query fails if no secondary region is available and not use primary ones.
From [driver docs](https://www.mongodb.com/docs/manual/core/read-preference/#mongodb-readmode-secondary):

> When the secondary read preference includes a maxStalenessSeconds value, the client estimates how stale each secondary is by comparing the secondary's last write to that of the primary. The client then directs the read operation to a secondary whose estimated lag is less than or equal to maxStalenessSeconds. If there is no primary, the client uses the secondary with the most recent write for the comparison.

<!--- Describe your changes in detail -->

#### Motivation and Context
Any help desk query must be performed on secondary region only
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.