### PR TITLE
fix: read correlation id also for transactions without requested authorization

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/helpdesk/utils/ResponseBuilderV2.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/helpdesk/utils/ResponseBuilderV2.kt
@@ -135,13 +135,10 @@ private fun getTransactionAuthRequestedData(
 private fun getTransactionActivatedData(
     baseTransaction: BaseTransaction
 ): TransactionActivatedData? =
-    when (baseTransaction) {
-        is BaseTransactionExpired ->
-            getTransactionActivatedData(baseTransaction.transactionAtPreviousState)
-        is BaseTransactionWithClosureError ->
-            getTransactionActivatedData(baseTransaction.transactionAtPreviousState)
-        is BaseTransactionWithRequestedAuthorization -> baseTransaction.transactionActivatedData
-        else -> null
+    if (baseTransaction is BaseTransactionWithPaymentToken) {
+        baseTransaction.transactionActivatedData
+    } else {
+        null
     }
 
 private fun getTransactionAuthCompletedData(

--- a/src/test/kotlin/it/pagopa/ecommerce/helpdesk/dataproviders/mongo/EcommerceForTransactionV2DataProviderTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/helpdesk/dataproviders/mongo/EcommerceForTransactionV2DataProviderTest.kt
@@ -32,7 +32,6 @@ import it.pagopa.generated.ecommerce.helpdesk.model.*
 import java.time.ZonedDateTime
 import java.util.*
 import java.util.stream.Stream
-import kotlin.collections.HashSet
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -234,6 +233,7 @@ class EcommerceForTransactionV2DataProviderTest {
                             .authorizationCode(null)
                             .paymentMethodName(null)
                             .brand(null)
+                            .correlationId(UUID.fromString(correlationId))
                     )
                     .paymentInfo(
                         PaymentInfoDto()
@@ -1147,6 +1147,7 @@ class EcommerceForTransactionV2DataProviderTest {
                             .authorizationCode(null)
                             .paymentMethodName(null)
                             .brand(null)
+                            .correlationId(UUID.fromString(correlationId))
                     )
                     .paymentInfo(
                         PaymentInfoDto()
@@ -1254,6 +1255,7 @@ class EcommerceForTransactionV2DataProviderTest {
                             .authorizationCode(null)
                             .paymentMethodName(null)
                             .brand(null)
+                            .correlationId(UUID.fromString(correlationId))
                     )
                     .paymentInfo(
                         PaymentInfoDto()


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Read NPG correlation id for all transactions, also for those who have no authorization requested
<!--- Describe your changes in detail -->

#### Motivation and Context
This fix NPG correlation id extraction reading correlation id for all transactions based on the fact that transaction have been activated and not that authorization have been requested
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Junit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.