### PR TITLE
feat: [CHK-3780] upgrade to helm chart 7 (on hold)

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: microservice-chart
   repository: https://pagopa.github.io/aks-microservice-chart-blueprint
-  version: 2.3.1
-digest: sha256:92b42c64847373faa6bf054181be2d7ee61e8b6b6d6a5552bf1479691aa95df3
-generated: "2023-06-07T17:32:48.719549+02:00"
+  version: 7.4.0
+digest: sha256:ba6c74f4d1b23251f9256f33bbc5ac6eaaf586569c0b43e37ad413f6d36ceabe
+generated: "2025-03-04T16:17:00.717256+01:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 1.35.3
 appVersion: 1.37.3
 dependencies:
   - name: microservice-chart
-    version: 2.3.1
+    version: 7.4.0
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,6 +2,20 @@ microservice-chart:
   namespace: "ecommerce"
   nameOverride: ""
   fullnameOverride: ""
+  canaryDelivery:
+    create: false
+    ingress:
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+      image:
+        repository: pagopadcommonacr.azurecr.io/pagopaecommercehelpdeskservice
+        tag: "latest"
+      envConfig: {}
+      envSecret: {}
   image:
     repository: pagopadcommonacr.azurecr.io/pagopaecommercehelpdeskservice
     tag: "1.37.3"
@@ -22,6 +36,7 @@ microservice-chart:
     periodSeconds: 10
   deployment:
     create: true
+    replicas: 1
   service:
     create: true
     type: ClusterIP
@@ -35,7 +50,7 @@ microservice-chart:
   serviceAccount:
     create: false
     annotations: {}
-    name: ""
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -128,7 +143,5 @@ microservice-chart:
                 operator: In
                 values:
                   - user
-  canaryDelivery:
-    deployment:
-      image:
-        tag: ""
+  azure:
+    workloadIdentityClientId: 1be61b58-24e2-49c8-b401-89ebd004bf2e

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -5,55 +5,19 @@ microservice-chart:
   canaryDelivery:
     create: false
     ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
-      image:
-        repository: pagopapcommonacr.azurecr.io/pagopaecommercehelpdeskservice
-        tag: "latest"
-        pullPolicy: Always
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopapcommonacr.azurecr.io/pagopaecommercehelpdeskservice
+      tag: "latest"
     envConfig:
-      DEFAULT_LOGGING_LEVEL: "info"
-      APP_LOGGING_LEVEL: "info"
-      WEB_LOGGING_LEVEL: "off"
       ECS_SERVICE_NAME: "pagopa-ecommerce-helpdesk-service-blue"
-      ECS_SERVICE_ENVIRONMENT: "prod"
       OTEL_RESOURCE_ATTRIBUTES: "service.name=pagopa-ecommerce-helpdesk-service-blue,deployment.environment=prod"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.elastic-system.svc:4317"
-      OTEL_LOGS_EXPORTER: none
-      OTEL_TRACES_SAMPLER: "always_on"
-      PERSONAL_DATA_VAULT_API_BASE_PATH: "https://api.tokenizer.pdv.pagopa.it/tokenizer/v1"
-      PM_ORACLE_PORT: "1523"
-      PM_ORACLE_DATABASE_NAME: "AZAGIDP"
-      PM_ORACLE_USERNAME: "PAGOPA_SV"
-      MONGO_HOST: pagopa-p-weu-ecommerce-cosmos-account.mongo.cosmos.azure.com
-      MONGO_USERNAME: pagopa-p-weu-ecommerce-cosmos-account
-      MONGO_PORT: "10256"
-      MONGO_SSL_ENABLED: "true"
-      MONGO_MIN_POOL_SIZE: "0"
-      MONGO_MAX_POOL_SIZE: "50"
-      MONGO_MAX_IDLE_TIMEOUT_MS: "600000"
-      MONGO_CONNECTION_TIMEOUT_MS: "2000"
-      MONGO_SOCKET_TIMEOUT_MS: "10000"
-      MONGO_SERVER_SELECTION_TIMEOUT_MS: "2000"
-      MONGO_WAITING_QUEUE_MS: "2000"
-      MONGO_HEARTBEAT_FREQUENCY_MS: "5000"
-      MONGO_REPLICA_SET_OPTION: "&replicaSet=globaldb"
-      SEARCH_DEAD_LETTER_QUEUE_MAPPING: >
-        {ALL: '*', ECOMMERCE: 'pagopa-p-weu-ecommerce-transactions-dead-letter-queue', NOTIFICATIONS_SERVICE: 'pagopa-p-weu-ecommerce-notifications-service-errors-queue'}
-
-      SEARCH_PM_IN_ECOMMERCE_HISTORY_ENABLED: "true"
-      SEARCH_PM_TRANSACTION_ID_RANGE_MAX: "10000"
-    envSecret:
-      OTEL_EXPORTER_OTLP_HEADERS: elastic-otel-token-header
-      PERSONAL_DATA_VAULT_API_KEY: personal-data-vault-api-key
-      PM_ORACLE_PASSWORD: pm-oracle-db-password
-      PM_ORACLE_HOST: pm-oracle-db-host
-      MONGO_PASSWORD: mongo-ecommerce-password
+    envSecret: { }
   image:
     repository: pagopapcommonacr.azurecr.io/pagopaecommercehelpdeskservice
     tag: "1.37.3"
@@ -88,7 +52,7 @@ microservice-chart:
   serviceAccount:
     create: false
     annotations: {}
-    name: ""
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -197,3 +161,5 @@ microservice-chart:
                 app.kubernetes.io/instance: pagopaecommercehelpdeskservice
             namespaces: ["ecommerce"]
             topologyKey: topology.kubernetes.io/zone
+  azure:
+    workloadIdentityClientId: "TBD"

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -5,54 +5,19 @@ microservice-chart:
   canaryDelivery:
     create: false
     ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
       image:
         repository: pagopaucommonacr.azurecr.io/pagopaecommercehelpdeskservice
         tag: "latest"
-        pullPolicy: Always
-    envConfig:
-      DEFAULT_LOGGING_LEVEL: "info"
-      APP_LOGGING_LEVEL: "info"
-      WEB_LOGGING_LEVEL: "off"
-      ECS_SERVICE_NAME: "pagopa-ecommerce-helpdesk-service-blue"
-      ECS_SERVICE_ENVIRONMENT: "uat"
-      OTEL_RESOURCE_ATTRIBUTES: "service.name=pagopa-ecommerce-helpdesk-service-blue,deployment.environment=uat"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector.elastic-system.svc:4317"
-      OTEL_LOGS_EXPORTER: none
-      OTEL_TRACES_SAMPLER: "always_on"
-      PERSONAL_DATA_VAULT_API_BASE_PATH: "https://api.uat.tokenizer.pdv.pagopa.it/tokenizer/v1"
-      PM_ORACLE_PORT: "1523"
-      PM_ORACLE_DATABASE_NAME: "AGIDAD"
-      PM_ORACLE_USERNAME: "pagopa_SV"
-      MONGO_HOST: pagopa-u-weu-ecommerce-cosmos-account.mongo.cosmos.azure.com
-      MONGO_USERNAME: pagopa-u-weu-ecommerce-cosmos-account
-      MONGO_PORT: "10255"
-      MONGO_SSL_ENABLED: "true"
-      MONGO_MIN_POOL_SIZE: "0"
-      MONGO_MAX_POOL_SIZE: "50"
-      MONGO_MAX_IDLE_TIMEOUT_MS: "600000"
-      MONGO_CONNECTION_TIMEOUT_MS: "2000"
-      MONGO_SOCKET_TIMEOUT_MS: "10000"
-      MONGO_SERVER_SELECTION_TIMEOUT_MS: "2000"
-      MONGO_WAITING_QUEUE_MS: "2000"
-      MONGO_HEARTBEAT_FREQUENCY_MS: "5000"
-      SEARCH_DEAD_LETTER_QUEUE_MAPPING: >
-        {ALL: '*', ECOMMERCE: 'pagopa-u-weu-ecommerce-transactions-dead-letter-queue', NOTIFICATIONS_SERVICE: 'pagopa-u-weu-ecommerce-notifications-service-errors-queue'}
-
-      SEARCH_PM_IN_ECOMMERCE_HISTORY_ENABLED: "true"
-      SEARCH_PM_TRANSACTION_ID_RANGE_MAX: "10000"
-    envSecret:
-      OTEL_EXPORTER_OTLP_HEADERS: elastic-otel-token-header
-      PERSONAL_DATA_VAULT_API_KEY: personal-data-vault-api-key
-      PM_ORACLE_PASSWORD: pm-oracle-db-password
-      PM_ORACLE_HOST: pm-oracle-db-host
-      MONGO_PASSWORD: mongo-ecommerce-password
+      envConfig:
+        ECS_SERVICE_NAME: "pagopa-ecommerce-helpdesk-service-blue"
+        OTEL_RESOURCE_ATTRIBUTES: "service.name=pagopa-ecommerce-helpdesk-service-blue,deployment.environment=uat"
+      envSecret: {}
   image:
     repository: pagopaucommonacr.azurecr.io/pagopaecommercehelpdeskservice
     tag: "1.37.3"
@@ -86,7 +51,7 @@ microservice-chart:
   serviceAccount:
     create: false
     annotations: {}
-    name: ""
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -179,3 +144,5 @@ microservice-chart:
                 operator: In
                 values:
                   - user
+  azure:
+    workloadIdentityClientId: 449c5b65-f368-487a-881a-b03676420c53


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

Upgrade to helm chart 7 from helm chart 2.

#### List of Changes
Upgrade to helm chart 7 performing the following modifications:
- chat version update from 2.3.1 to 7.4.0
- canaryDelivery parameter update to the new template (adding canary section)
- add workload identity refs for each environment specifying the azure workload identity client id and service account name for each env
- simplified env configs and env secrets for canary section, defining just the different ones

#### Motivation and Context
These modifications are needed to enable the eCommerce helpdesk service to use workload identities instead of the deprecated pod identity.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

not yet tested

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.