### PR TITLE
feat(api-key): [CHK-4302] updated integration tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,3 +53,7 @@ PERSONAL_DATA_VAULT_API_KEY_FISCAL_CODE: personal-data-vault-api-key-wallet-sess
 PERSONAL_DATA_VAULT_API_BASE_PATH="http://pagopa-pdv-mock:8080"
 
 SEARCH_PM_TRANSACTION_ID_RANGE_MAX=10
+
+SECURITY_API_KEY_SECURED_PATHS=/v2/helpdesk,/v2/ecommerce,/ecommerce,/helpdesk,/pm
+SECURITY_API_KEY_PRIMARY=primary-key
+SECURITY_API_KEY_SECONDARY=secondary-key

--- a/api-tests/env/helpDesk_local.env.json
+++ b/api-tests/env/helpDesk_local.env.json
@@ -1,5 +1,5 @@
 {
-	"id": "ab94684f-e2b6-4687-9006-e43bb7b5a787",
+	"id": "17fd20cd-e385-49e9-ad47-8bb148f57869",
 	"name": "eCommerce helpDesk LOCAL",
 	"values": [
 		{
@@ -73,9 +73,27 @@
 			"value": "green",
 			"type": "green",
 			"enabled": true
+		},
+		{
+			"key": "SECURITY_API_KEY_PRIMARY",
+			"value": "primary-key",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "SECURITY_API_KEY_SECONDARY",
+			"value": "secondary-key",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "SECURITY_API_KEY_INVALID",
+			"value": "invalid-key",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2024-05-09T10:40:17.920Z",
-	"_postman_exported_using": "Postman/10.24.24"
+	"_postman_exported_at": "2025-06-27T15:24:19.762Z",
+	"_postman_exported_using": "Postman/11.51.4"
 }

--- a/api-tests/v1/eCommerce-helpdesk.api.tests.local.json
+++ b/api-tests/v1/eCommerce-helpdesk.api.tests.local.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "0235f502-5b9a-477d-b7df-f7ba0c241929",
+		"_postman_id": "53b04f35-cf4d-4955-b905-ff66f5bfa8d6",
 		"name": "Ecommerce helpDesk-service LOCAL",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
-		"_exporter_id": "38770380"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "46258243"
 	},
 	"item": [
 		{
@@ -28,6 +28,9 @@
 				}
 			],
 			"request": {
+				"auth": {
+					"type": "noauth"
+				},
 				"method": "POST",
 				"header": [
 					{
@@ -38,6 +41,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -106,6 +114,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -172,6 +185,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -240,6 +258,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -306,6 +329,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -374,6 +402,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -440,6 +473,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -508,6 +546,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -574,6 +617,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -674,6 +722,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -740,6 +793,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -808,6 +866,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -869,6 +932,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -932,6 +1000,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -994,6 +1067,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -1043,7 +1121,8 @@
 							"    pm.expect(response.operations).to.not.be.empty; ",
 							"});"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -1059,6 +1138,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -1070,7 +1154,16 @@
 						}
 					}
 				},
-				"url": "{{HOSTNAME}}/ecommerce/searchNpgOperations"
+				"url": {
+					"raw": "{{HOSTNAME}}/ecommerce/searchNpgOperations",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"ecommerce",
+						"searchNpgOperations"
+					]
+				}
 			},
 			"response": []
 		},
@@ -1089,7 +1182,8 @@
 							"    pm.expect(response.detail).to.include(requestBody.idTransaction);",
 							"});"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -1105,6 +1199,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -1116,7 +1215,16 @@
 						}
 					}
 				},
-				"url": "{{HOSTNAME}}/ecommerce/searchNpgOperations"
+				"url": {
+					"raw": "{{HOSTNAME}}/ecommerce/searchNpgOperations",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"ecommerce",
+						"searchNpgOperations"
+					]
+				}
 			},
 			"response": []
 		},
@@ -1134,7 +1242,8 @@
 							"    pm.expect(response.detail).to.include(\"Input request is invalid\");",
 							"});"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -1150,6 +1259,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -1161,7 +1275,151 @@
 						}
 					}
 				},
-				"url": "{{HOSTNAME}}/ecommerce/searchNpgOperations"
+				"url": {
+					"raw": "{{HOSTNAME}}/ecommerce/searchNpgOperations",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"ecommerce",
+						"searchNpgOperations"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "eCommerce SearchTransaction UNAUTHORIZED 401 - Missing api key",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"eCommerce SearchTransaction by TRANSACTION_ID - Status code is 200 with valid json response\", function () {",
+							"    pm.response.to.have.status(401);",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{API_SUBSCRIPTION_KEY}}",
+						"type": "text"
+					},
+					{
+						"key": "deployment",
+						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"type\": \"TRANSACTION_ID\",\n  \"transactionId\": \"{{TRANSACTION_ID}}\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{HOSTNAME}}/ecommerce/searchTransaction?pageNumber=0&pageSize=10",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"ecommerce",
+						"searchTransaction"
+					],
+					"query": [
+						{
+							"key": "pageNumber",
+							"value": "0"
+						},
+						{
+							"key": "pageSize",
+							"value": "10"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "eCommerce SearchTransaction UNAUTHORIZED 401 - Invalid api key",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"eCommerce SearchTransaction by TRANSACTION_ID - Status code is 200 with valid json response\", function () {",
+							"    pm.response.to.have.status(401);",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{API_SUBSCRIPTION_KEY}}",
+						"type": "text"
+					},
+					{
+						"key": "deployment",
+						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_INVALID}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"type\": \"TRANSACTION_ID\",\n  \"transactionId\": \"{{TRANSACTION_ID}}\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{HOSTNAME}}/ecommerce/searchTransaction?pageNumber=0&pageSize=10",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"ecommerce",
+						"searchTransaction"
+					],
+					"query": [
+						{
+							"key": "pageNumber",
+							"value": "0"
+						},
+						{
+							"key": "pageSize",
+							"value": "10"
+						}
+					]
+				}
 			},
 			"response": []
 		}

--- a/api-tests/v2/eCommerce-helpdesk.api.tests.local.json
+++ b/api-tests/v2/eCommerce-helpdesk.api.tests.local.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "d9363f35-53c4-4d20-97a2-a3bb5d282e1f",
+		"_postman_id": "5fefaa9e-d47c-4189-9447-89212f682cf2",
 		"name": "Ecommerce helpDesk-service LOCAL (v2)",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
-		"_exporter_id": "9864793"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "46258243"
 	},
 	"item": [
 		{
@@ -39,6 +39,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -109,6 +114,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -178,6 +188,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -241,6 +256,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -276,7 +296,6 @@
 			},
 			"response": []
 		},
-
 		{
 			"name": "Technical helpDesk SearchTransaction (v2)  TRANSACTION_ID",
 			"event": [
@@ -309,6 +328,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -377,6 +401,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -443,6 +472,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -511,6 +545,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -561,7 +600,8 @@
 							"    pm.expect(response.page.results).to.be.lte(10);",
 							"});"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -576,6 +616,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -627,7 +672,8 @@
 							"    pm.expect(response.page.results).to.be.lte(10);",
 							"});"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -642,6 +688,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -705,6 +756,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -766,6 +822,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -829,6 +890,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -890,6 +956,11 @@
 					{
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
 						"type": "text"
 					}
 				],
@@ -953,6 +1024,11 @@
 						"key": "deployment",
 						"value": "{{DEPLOYMENT}}",
 						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_PRIMARY}}",
+						"type": "text"
 					}
 				],
 				"body": {
@@ -981,6 +1057,137 @@
 						{
 							"key": "pageSize",
 							"value": "21"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "eCommerce SearchTransaction (v2) UNAUTHORIZED 401 - Invalid api key",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"eCommerce SearchTransaction by TRANSACTION_ID - Status code is 200 with valid json response\", function () {",
+							"    pm.response.to.have.status(401);",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{API_SUBSCRIPTION_KEY}}",
+						"type": "text"
+					},
+					{
+						"key": "deployment",
+						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					},
+					{
+						"key": "x-api-key",
+						"value": "{{SECURITY_API_KEY_INVALID}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"type\": \"TRANSACTION_ID\",\n  \"transactionId\": \"{{TRANSACTION_ID}}\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{HOSTNAME}}/v2/ecommerce/searchTransaction?pageNumber=0&pageSize=10",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"v2",
+						"ecommerce",
+						"searchTransaction"
+					],
+					"query": [
+						{
+							"key": "pageNumber",
+							"value": "0"
+						},
+						{
+							"key": "pageSize",
+							"value": "10"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "eCommerce SearchTransaction (v2) UNAUTHORIZED 401 - Missing api key",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"eCommerce SearchTransaction by TRANSACTION_ID - Status code is 200 with valid json response\", function () {",
+							"    pm.response.to.have.status(401);",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{API_SUBSCRIPTION_KEY}}",
+						"type": "text"
+					},
+					{
+						"key": "deployment",
+						"value": "{{DEPLOYMENT}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"type\": \"TRANSACTION_ID\",\n  \"transactionId\": \"{{TRANSACTION_ID}}\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{HOSTNAME}}/v2/ecommerce/searchTransaction?pageNumber=0&pageSize=10",
+					"host": [
+						"{{HOSTNAME}}"
+					],
+					"path": [
+						"v2",
+						"ecommerce",
+						"searchTransaction"
+					],
+					"query": [
+						{
+							"key": "pageNumber",
+							"value": "0"
+						},
+						{
+							"key": "pageSize",
+							"value": "10"
 						}
 					]
 				}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Updated Postman collections (v1 and v2) for eCommerce helpdesk service to:
  - Include the x-api-key header in all secured requests.
  - Add test cases for requests with missing or invalid API keys (expecting 401 Unauthorized responses).
  - Ensure consistency in key injection for both legacy (/ecommerce) and versioned (/v2/ecommerce) endpoints.
<!--- Describe your changes in detail -->

#### Motivation and Context
Aligns the Postman-based integration tests with recent backend changes introducing API key authentication on selected endpoints
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.